### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ tokenizer = model.sequence_encoder.tokenizer
 Example sample embedding
 
 ```py
+import torch
+
 # Input sample
 sequences = [
     "ACTGCAG",
@@ -34,7 +36,7 @@ sequences = [
 ]
 
 # Tokenize sequences in the sample
-sequence_tokens = torch.stack([tokenizer(s) for s in sequences])
+sequence_tokens = torch.stack([torch.tensor(tokenizer(s)) for s in sequences])
 
 # Compute embeddings
 output = model(sequence_tokens)


### PR DESCRIPTION
Torch wasn't imported by default, so I added the needed import.

I also saw this error using torch.stack():

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[31], line 11
      4 sequences = [
      5     "ACTGCAG",
      6     "TGACGTA",
      7     "ATGACGA"
      8 ]
     10 # Tokenize sequences in the sample
---> 11 sequence_tokens = torch.stack([tokenizer(s) for s in sequences])
     13 # Compute embeddings
     14 output = model(sequence_tokens)

TypeError: expected Tensor as element 0 in argument 0, but got list
```
So, I wrapped each of the individual lists with torch.tensor() before passing the list of them to torch.stack().
